### PR TITLE
ChessGame Refactor for Arena

### DIFF
--- a/azg_chess/chess_utils.py
+++ b/azg_chess/chess_utils.py
@@ -27,16 +27,14 @@ def to_display(board: chess.Board, *, verbosity: int = 0, pretty: bool = False) 
     rows = board.unicode(empty_square=".") if pretty else str(board).split("\n")
     if verbosity == 0:
         return os.linesep.join(rows)
-    elif verbosity == 1:
-        board_string = os.linesep.join(
-            "%d %s" % (8 - i, row) for i, row in enumerate(rows)
-        )
+    if verbosity == 1:
+        board_string = os.linesep.join(f"{8-i} {row}" for i, row in enumerate(rows))
         return f"  a b c d e f g h{os.linesep}{board_string}"
-    elif verbosity == 2:
+    if verbosity == 2:
         top_corner = "*" if board.turn == chess.BLACK else "."
         bottom_corner = "*" if board.turn == chess.WHITE else "."
         board_string = os.linesep.join(
-            "%d | %s | %d" % (8 - i, row, 8 - i) for i, row in enumerate(rows)
+            f"{8-i} | {row} | {8-i}" for i, row in enumerate(rows)
         )
         return (
             f"    a b c d e f g h{os.linesep}"

--- a/azg_chess/chess_utils.py
+++ b/azg_chess/chess_utils.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import chess
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def to_display(board: chess.Board, *, verbosity: int = 0, pretty: bool = False) -> str:
+    """
+    Convert the input board to a displayable representation.
+
+    SEE: https://github.com/niklasf/python-chess/issues/971#issuecomment-1464138409
+
+    Args:
+        board: Board to display.
+        verbosity: Verbosity level (0: no labels, 1: compressed labels,
+            2: full labels).
+        pretty: Prettify the print (use unicode characters).
+
+    Returns:
+        String representation to pass to print.
+    """
+    rows = board.unicode(empty_square=".") if pretty else str(board).split("\n")
+    if verbosity == 0:
+        return os.linesep.join(rows)
+    elif verbosity == 1:
+        board_string = os.linesep.join(
+            "%d %s" % (8 - i, row) for i, row in enumerate(rows)
+        )
+        return f"  a b c d e f g h{os.linesep}{board_string}"
+    elif verbosity == 2:
+        top_corner = "*" if board.turn == chess.BLACK else "."
+        bottom_corner = "*" if board.turn == chess.WHITE else "."
+        board_string = os.linesep.join(
+            "%d | %s | %d" % (8 - i, row, 8 - i) for i, row in enumerate(rows)
+        )
+        return (
+            f"    a b c d e f g h{os.linesep}"
+            f"  {top_corner} --------------- {top_corner}{os.linesep}"
+            f"{board_string}{os.linesep}"
+            f"  {bottom_corner} --------------- {bottom_corner}{os.linesep}"
+            f"    a b c d e f g h"
+        )
+    raise NotImplementedError(f"Unimplemented verbosity {verbosity}.")
+
+
+def make_display_func(
+    print_func: Callable[[str], None] = print, **to_display_kwargs
+) -> Callable[[chess.Board], None]:
+    """Get a function to display a board."""
+    return lambda b: print_func(to_display(b, **to_display_kwargs))

--- a/azg_chess/game.py
+++ b/azg_chess/game.py
@@ -95,7 +95,7 @@ class ChessGame(Game):
         board = self.getCanonicalForm(board, player)
         move = action_to_move(action)
         if (
-            board.piece_at(move.from_square).piece_type == chess.PAWN
+            board.piece_type_at(move.from_square) == chess.PAWN
             and chess.square_rank(move.to_square) in _EIGHTH_RANK
         ):
             move.promotion = chess.QUEEN  # Assume always queening

--- a/azg_chess/game.py
+++ b/azg_chess/game.py
@@ -87,7 +87,7 @@ class ChessGame(Game):
             and chess.square_rank(move.to_square) in _EIGHTH_RANK
         ):
             move.promotion = chess.QUEEN  # Assume always queening
-        board.push(move=move)
+        board.push(move=move)  # NOTE: this flips board.turn
         return board, -1 * player
 
     INVALID_MOVE = False
@@ -142,8 +142,9 @@ class ChessGame(Game):
         Returns:
             Canonical form of the board.
         """
-        if player == BLACK_PLAYER:
-            board.apply_mirror()  # Mirror vertically, swap piece colors, etc.
+        if board.turn == chess.BLACK:
+            # Mirror vertically, swap piece colors, flip board.turn, etc.
+            board.apply_mirror()
         return board  # NOTE: this is not a copy
 
     def getSymmetries(self, board: Board, pi: Policy) -> list[tuple[Board, Policy]]:

--- a/azg_chess/game.py
+++ b/azg_chess/game.py
@@ -114,10 +114,10 @@ class ChessGame(Game):
 
     def getGameEnded(self, board: Board, player: PlayerID) -> float:
         """Get the current reward associated with the board and player."""
-        result: str = board.result()
-        if result == "*":
+        white_result: str = board.result()
+        if white_result == "*":
             return self.UNFINISHED_REWARD
-        white_player_outcome = result.split("-")[0]
+        white_player_outcome = white_result.split("-")[0]
         match player == WHITE_PLAYER, white_player_outcome == "1", white_player_outcome == "0":
             case (True, True, _) | (False, _, True):
                 return self.WON_REWARD

--- a/azg_chess/game.py
+++ b/azg_chess/game.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, TypeAlias
@@ -43,7 +41,7 @@ INVALID_MOVE = False
 VALID_MOVE = True
 
 
-def get_moves(game: Game, board: Board) -> npt.NDArray[bool]:
+def get_moves(game: Game, board: Board) -> "npt.NDArray[bool]":
     """
     Get a vector that identifies moves as invalid False or valid True.
 

--- a/azg_chess/players.py
+++ b/azg_chess/players.py
@@ -42,7 +42,7 @@ class RandomPlayer(Player):
         self._rng = np.random.default_rng(seed)
 
     def choose_move(self, board: Board) -> chess.Move:
-        return self._rng.choice(list(board.legal_moves))
+        return self._rng.choice(list(board.legal_moves))  # type: ignore[arg-type]
 
 
 class HumanChessPlayer(Player):

--- a/azg_chess/requirements.txt
+++ b/azg_chess/requirements.txt
@@ -2,3 +2,5 @@
 chess
 numpy>=1.21  # For numpy.typing
 # azg
+coloredlogs
+tqdm

--- a/azg_chess/test.py
+++ b/azg_chess/test.py
@@ -1,0 +1,155 @@
+import math
+from operator import gt, lt
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import chess
+import pytest
+from azg.Arena import Arena
+
+from azg_chess.chess_utils import make_display_func
+from azg_chess.game import (
+    BLACK_PLAYER,
+    BOARD_DIMENSIONS,
+    INVALID_MOVE,
+    NUM_SQUARES,
+    VALID_MOVE,
+    WHITE_PLAYER,
+    ChessGame,
+    PlayerID,
+)
+from azg_chess.players import StockfishPlayer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.fixture(name="chess_game")
+def fixture_chess_game() -> ChessGame:
+    return ChessGame()
+
+
+@pytest.fixture(name="chess_board")
+def fixture_chess_board() -> chess.Board:
+    return chess.Board()
+
+
+class TestGame:
+    def test_constants(self) -> None:
+        # Module-level constants
+        assert math.prod(BOARD_DIMENSIONS) == NUM_SQUARES
+        assert WHITE_PLAYER == int(chess.WHITE)
+        assert BLACK_PLAYER != WHITE_PLAYER
+        assert not INVALID_MOVE
+        assert VALID_MOVE
+
+        # Game constants
+        assert ChessGame.LOST_REWARD == -1
+        assert ChessGame.WON_REWARD == 1
+        assert ChessGame.UNFINISHED_REWARD == 0
+        assert ChessGame.DRAW_REWARD not in [-1, 0, 1]
+        assert 0 < abs(ChessGame.DRAW_REWARD) < 1
+
+    def test_game_sizings(self, chess_game: ChessGame) -> None:
+        assert chess_game.getBoardSize() == (8, 8)
+        assert chess_game.getActionSize() == 4096
+        assert isinstance(chess_game.getInitBoard(), chess.Board)
+
+    def test_stringRepresentation(
+        self, chess_game: ChessGame, chess_board: chess.Board
+    ) -> None:
+        repr_before_move = chess_game.stringRepresentation(chess_board)
+        assert isinstance(repr_before_move, str)
+
+        chess_board.push(chess.Move.from_uci("a2a4"))
+        repr_after_move = chess_game.stringRepresentation(chess_board)
+
+        reprs = [repr_after_move, repr_before_move]
+        assert len(set(reprs)) == len(reprs)  # Confirm unique
+        for rep in reprs:
+            assert isinstance(rep, str)
+
+    @pytest.mark.parametrize(
+        ("player", "board_turn", "board_result", "ended_return", "winner"),
+        [
+            (WHITE_PLAYER, chess.WHITE, "1-0", ChessGame.WON_REWARD, WHITE_PLAYER),
+            (WHITE_PLAYER, chess.WHITE, "0-1", ChessGame.LOST_REWARD, BLACK_PLAYER),
+            (WHITE_PLAYER, chess.BLACK, "1-0", ChessGame.WON_REWARD, WHITE_PLAYER),
+            (WHITE_PLAYER, chess.BLACK, "0-1", ChessGame.LOST_REWARD, BLACK_PLAYER),
+            (BLACK_PLAYER, chess.WHITE, "1-0", ChessGame.LOST_REWARD, WHITE_PLAYER),
+            (BLACK_PLAYER, chess.WHITE, "0-1", ChessGame.WON_REWARD, BLACK_PLAYER),
+            (BLACK_PLAYER, chess.BLACK, "1-0", ChessGame.LOST_REWARD, WHITE_PLAYER),
+            (BLACK_PLAYER, chess.BLACK, "0-1", ChessGame.WON_REWARD, BLACK_PLAYER),
+            # fmt: off
+            (WHITE_PLAYER, chess.WHITE, "1/2-1/2", ChessGame.DRAW_REWARD, ChessGame.DRAW_REWARD),
+            (WHITE_PLAYER, chess.BLACK, "1/2-1/2", ChessGame.DRAW_REWARD, ChessGame.DRAW_REWARD),
+            (BLACK_PLAYER, chess.WHITE, "1/2-1/2", ChessGame.DRAW_REWARD, -ChessGame.DRAW_REWARD),
+            (BLACK_PLAYER, chess.BLACK, "1/2-1/2", ChessGame.DRAW_REWARD, -ChessGame.DRAW_REWARD),
+            # fmt: on
+        ],
+    )
+    def test_getGameEnded(
+        self,
+        chess_game: ChessGame,
+        chess_board: chess.Board,
+        player: PlayerID,
+        board_turn: bool,
+        board_result: str,
+        ended_return: float,
+        winner: float,
+    ) -> None:
+        with (
+            patch.object(chess_board, "result", return_value=board_result),
+            patch.object(chess_board, "turn", board_turn),
+        ):
+            assert (
+                chess_game.getGameEnded(board=chess_board, player=player)
+                == ended_return
+            )
+            assert (
+                chess_game.getGameEnded(board=chess_board, player=player) * player
+                == winner
+            )
+
+    @patch.object(chess.Board, "apply_mirror")
+    def test_getCanonicalForm(
+        self,
+        mock_apply_mirror: MagicMock,
+        chess_game: ChessGame,
+        chess_board: chess.Board,
+    ) -> None:
+        with patch.object(chess_board, "turn", chess.WHITE):
+            assert isinstance(
+                chess_game.getCanonicalForm(chess_board, WHITE_PLAYER), chess.Board
+            )
+            assert isinstance(
+                chess_game.getCanonicalForm(chess_board, BLACK_PLAYER), chess.Board
+            )
+        mock_apply_mirror.assert_not_called()
+
+        with patch.object(chess_board, "turn", chess.BLACK):
+            with pytest.raises(NotImplementedError, match="(?i)unreachable"):
+                chess_game.getCanonicalForm(chess_board, WHITE_PLAYER)
+            mock_apply_mirror.assert_not_called()
+            assert isinstance(
+                chess_game.getCanonicalForm(chess_board, BLACK_PLAYER), chess.Board
+            )
+            mock_apply_mirror.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("white_elo", "black_elo", "comparison"), [(1400, 2600, lt), (2600, 1400, gt)]
+)
+def test_full_game(
+    chess_game: ChessGame,
+    white_elo: int,
+    black_elo: int,
+    comparison: "Callable[[int, int], bool]",
+) -> None:
+    white_player = StockfishPlayer(engine_elo=white_elo)
+    black_player = StockfishPlayer(BLACK_PLAYER, engine_elo=black_elo)
+    arena = Arena(
+        white_player, black_player, chess_game, display=make_display_func(verbosity=2)
+    )
+    n_p1_wins, n_p2_wins, _ = arena.playGames(4)
+    assert comparison(n_p1_wins, n_p2_wins)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ pretty = true
 # Shows a short summary line after error messages.
 error_summary = false
 
+# A comma-separated list of mypy plugins
+plugins = ["numpy.typing.mypy_plugin"]
+
 
 [tool.flake8]
 # SEE: https://flake8.pycqa.org/en/latest/user/options.html

--- a/requirements-qa.txt
+++ b/requirements-qa.txt
@@ -4,3 +4,4 @@ mypy
 pre-commit
 pylint[spelling]
 pytest
+types-tqdm

--- a/requirements-qa.txt
+++ b/requirements-qa.txt
@@ -1,4 +1,6 @@
+coverage
 ipython  # For PyCharm debugging
 mypy
 pre-commit
 pylint[spelling]
+pytest


### PR DESCRIPTION
Turns out I had some misunderstandings about `Game` implementations that surfaced when I implemented against `Arena.py`.
- Refactors `Player` to:
    - Implement `__call__` as an alias for `choose_move`
    - Not require a `Game` as an instance attribute, by externalizing `get_moves` to a free function
- Refactors `ChessGame` to:
    - Not house players as attributes
    - Fix pawn promotion logic
    - Fix canonical board and getting next state logic (with lots of comments)
- Adds `to_display`/`make_display_func` utilities for debugging
- Adds full test suite for `ChessGame`