### PR TITLE
NNetWrapper.train

### DIFF
--- a/azg_chess/nn.py
+++ b/azg_chess/nn.py
@@ -66,6 +66,8 @@ def conv3d_calc(
 
 
 class NNet(nn.Module):
+    """Neural network takes in a board embedding to predict policy logits and value."""
+
     KERNEL_SIZE = 3  # Square
 
     def __init__(self, game: ChessGame, num_channels: int = 64, dropout_p: float = 0.5):
@@ -123,7 +125,7 @@ class NNet(nn.Module):
 
 
 class NNetWrapper(NeuralNet):
-    """Neural network adaptation for chess."""
+    """Neural network wrapper adaptation for chess."""
 
     def __init__(self, game: ChessGame, **nnet_kwargs):
         super().__init__(game)

--- a/azg_chess/nn.py
+++ b/azg_chess/nn.py
@@ -46,27 +46,23 @@ def embed(*boards: Board) -> npt.NDArray[int]:
     return embedding
 
 
-def conv3d_calc(
-    d_h_w_in: tuple[int, int, int],
-    kernel_size: int,
-    padding: int | tuple[int, int, int] = 0,
-    dilation: int | tuple[int, int, int] = 1,
-    stride: int | tuple[int, int, int] = 1,
-) -> tuple[int, int, int]:
-    """Perform a Conv3d calculation matching nn.Conv3D's defaults."""
+def conv_conversion(
+    in_shape: tuple[int, ...],
+    kernel_size: int | tuple[int, ...],
+    padding: int | tuple[int, ...] = 0,
+    dilation: int | tuple[int, ...] = 1,
+    stride: int | tuple[int, ...] = 1,
+) -> tuple[int, ...]:
+    """Perform a Conv layer calculation matching nn.Conv's defaults."""
 
-    def to_3_tuple(value: int | tuple[int, int, int]) -> tuple[int, int, int]:
-        if isinstance(value, int):
-            value = (value,) * 3
-        return value
+    def to_tuple(value: int | tuple[int, ...]) -> tuple[int, ...]:
+        return (value,) * len(in_shape) if isinstance(value, int) else value
 
-    k = to_3_tuple(kernel_size)
-    p = to_3_tuple(padding)
-    dil = to_3_tuple(dilation)
-    s = to_3_tuple(stride)
+    k, p = to_tuple(kernel_size), to_tuple(padding)
+    dil, s = to_tuple(dilation), to_tuple(stride)
     return tuple(
-        int((d_h_w_in[i] + 2 * p[i] - dil[i] * (k[i] - 1) - 1) / s[i] + 1)
-        for i in range(3)
+        int((in_shape[i] + 2 * p[i] - dil[i] * (k[i] - 1) - 1) / s[i] + 1)
+        for i in range(len(in_shape))
     )
 
 
@@ -101,8 +97,9 @@ class NNet(nn.Module):
         )
         # NOTE: this matches the above sequential conv's hyperparameters
         assert game.getBoardSize() == EMBEDDING_SHAPE[1:]
-        conv_out_shape = conv3d_calc(
-            conv3d_calc(EMBEDDING_SHAPE, self.KERNEL_SIZE), self.KERNEL_SIZE
+        conv_out_shape = conv_conversion(
+            conv_conversion(EMBEDDING_SHAPE, self.KERNEL_SIZE),
+            self.KERNEL_SIZE,
         )
         self._fc_layers_shape = num_channels * math.prod(conv_out_shape)
         self.fc_layers = nn.Sequential(
@@ -113,20 +110,25 @@ class NNet(nn.Module):
             nn.BatchNorm1d(512),
             nn.Dropout(dropout_p),
         )
-        self.policy_head = nn.Sequential(
-            nn.Linear(512, game.getActionSize()), nn.Softmax(dim=1)
-        )
+        # NOTE: leave as raw scores to directly use nn.functional.cross_entropy
+        self.policy_head = nn.Linear(512, game.getActionSize())
         self.value_head = nn.Sequential(nn.Linear(512, 1), nn.Tanh())
 
     def forward(self, board: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        """Forward pass given an embedded board batch of shape (B, D, X, Y)."""
+        """
+        Run a forward pass on embedded board batch, getting policy scores and value.
+
+        Args:
+            board: Embedded canonical board batch of shape (B, D, X, Y).
+
+        Returns:
+            Tuple of policy scores of shape (B, |A|), value in [-1, 1] of shape (B, 1).
+        """
         s = board.unsqueeze(1)  # B, 1, D, X, Y
         s = self.conv_layers(s)  # B, C, D - 2 * 2, X - 2 * 2, Y - 2 * 2
         s = s.reshape(-1, self._fc_layers_shape)  # B, C * (D - 4) * (X - 4) * (Y - 4)
         s = self.fc_layers(s)  # B, 512
-        pi = self.policy_head(s)  # B, |A|
-        v = self.value_head(s)  # B, 1
-        return pi, v
+        return self.policy_head(s), self.value_head(s)  # (B, |A|), (B, 1)
 
 
 class NNetWrapper(NeuralNet):
@@ -136,7 +138,7 @@ class NNetWrapper(NeuralNet):
         super().__init__(game)
         self.nnet = NNet(game, **nnet_kwargs)
 
-    def train(
+    def train(  # pylint: disable=too-many-locals
         self,
         examples: Sequence[tuple[Board, Policy, int]],
         epochs: int = 10,
@@ -168,27 +170,25 @@ class NNetWrapper(NeuralNet):
                 range(math.ceil(len(examples) / batch_size)), desc=f"Epoch {epoch}"
             )
             for i in t:
-                boards, pis, vs = list(
+                boards, true_pis, true_vs = list(
                     zip(*examples[i * batch_size : (i + 1) * batch_size])
                 )
                 # FloatTensor is needed for gradient
-                out_pi, out_v = self.nnet(torch.FloatTensor(embed(*boards)))
-                # TODO: move to torch functions for this
-                target_pis = torch.FloatTensor(pis)
-                l_pi = self.loss_pi(target_pis, out_pi)
-                l_v = nn.functional.mse_loss(torch.FloatTensor(vs), out_v.reshape(-1))
+                pred_pis, pred_vs = self.nnet(torch.FloatTensor(embed(*boards)))
+                l_pi = nn.functional.cross_entropy(
+                    input=pred_pis, target=torch.FloatTensor(true_pis)
+                )
+                l_v = nn.functional.mse_loss(
+                    input=pred_vs.reshape(-1),
+                    target=torch.FloatTensor(true_vs),
+                )
                 pi_losses.update(val=l_pi.item(), n=len(boards))
                 v_losses.update(val=l_v.item(), n=len(boards))
-                # TODO: check how this looks
-                t.set_postfix(policy_loss=pi_losses, value_loss=v_losses)
+                t.set_postfix(pi_loss=pi_losses, v_loss=v_losses)
 
                 optimizer.zero_grad()
                 torch.Tensor.backward(l_pi + l_v)  # Backprop on total loss
                 optimizer.step()
-
-    # TODO: remove
-    def loss_pi(self, targets: torch.Tensor, outputs: torch.Tensor):
-        return -torch.sum(targets * outputs) / targets.size()[0]
 
     def predict(self, board: Board) -> tuple[Policy, float]:
         """
@@ -204,9 +204,8 @@ class NNetWrapper(NeuralNet):
         with torch.no_grad():
             # FloatTensor is needed for gradient
             pi, v = self.nnet(torch.FloatTensor(embed(board)))
-        hi = pi[0].numpy(), float(v[0])  # Unbatch
-        assert all((hi[0] >= 0) & (hi[0] <= 1)), f"Negative logprob in {hi[0]}."
-        return hi
+        # NOTE: [0] is to unbatch
+        return nn.functional.softmax(pi, dim=1)[0].numpy(), float(v[0])
 
     def save_checkpoint(self, folder: str, filename: str) -> None:
         """Save the NN's parameters to the folder/filename."""

--- a/azg_chess/players.py
+++ b/azg_chess/players.py
@@ -126,7 +126,7 @@ class MCTSArgs(NamedTuple):
 
 
 class AlphaZeroChessPlayer(ChessPlayer):
-    """Players whose decides via a trained AlphaGo Zero-style network."""
+    """Player whose decides via a trained AlphaGo Zero-style network."""
 
     DEFAULT_MCTS_ARGS = MCTSArgs()
 

--- a/azg_chess/test.py
+++ b/azg_chess/test.py
@@ -168,7 +168,7 @@ class CoachArgs(MCTSArgs):
     # Number of training iterations
     numIters: int = 1000
     # Number of self-play games per training iteration
-    numEps: int = 5
+    numEps: int = 100
     # Number of iterations to pass before increasing MCTS temp by 1
     tempThreshold: int = 15
     # Threshold win percentage of arena games to accept a new neural network

--- a/azg_chess/test.py
+++ b/azg_chess/test.py
@@ -167,7 +167,7 @@ class CoachArgs(MCTSArgs):
 
     # Number of training iterations
     numIters: int = 1000
-    # Number of self-play games per training iteration
+    # Number of self-play games (episodes) per training iteration
     numEps: int = 100
     # Number of iterations to pass before increasing MCTS temp by 1
     tempThreshold: int = 15


### PR DESCRIPTION
- Renames `embed_board` to `embed` and allows it to support a single board or a batch
- Renames `conv3d_calc` to `conv_conversion` and support arbitrary conv dimensions
- Closes the loop on training of `NNet`:
    - `policy_head` stops after a dense layer
    - Adds L2 regularization into training
    - Integrates CE loss and MSE loss per AlphaZero
    - Integrates progress bar to update user
- Fixes default number of episodes and better documents