### PR TITLE
TestNNet.play_against_stockfish and play_game_update_elo

### DIFF
--- a/azg_chess/chess_utils.py
+++ b/azg_chess/chess_utils.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, TypeAlias
 
 import chess
 
@@ -55,8 +55,10 @@ pprint = make_display_func(verbosity=2)  # For convenience
 
 ICC_K_FACTOR = 32
 
+Elo: TypeAlias = int
 
-def get_k_factor(p1_elo: int, p2_elo: int, org: str = "icc") -> int:
+
+def get_k_factor(p1_elo: Elo, p2_elo: Elo, org: str = "icc") -> int:
     """
     Get a K-factor per a chess organization's standard.
 
@@ -82,8 +84,8 @@ def get_k_factor(p1_elo: int, p2_elo: int, org: str = "icc") -> int:
 
 
 def update_elo(
-    p1_elo: int, p2_elo: int, winner: Literal[-1, 0, 1], k: int = ICC_K_FACTOR
-) -> tuple[int, int]:
+    p1_elo: Elo, p2_elo: Elo, winner: Literal[-1, 0, 1], k: int = ICC_K_FACTOR
+) -> tuple[Elo, Elo]:
     """
     Calculate the new Elo for P1 and P2 after the match.
 

--- a/azg_chess/nn.py
+++ b/azg_chess/nn.py
@@ -35,7 +35,7 @@ def embed(*boards: Board) -> npt.NDArray[int]:
     Returns:
         Embedded representation of the board of shape (B, 8, 8, 6), where B is
             the batch size (number passed in), white is 1, black is -1, no
-            piece is 0, and layers are pawns (0), knight (1), bishop (2),
+            piece is 0, and players are pawn (0), knight (1), bishop (2),
             rook (3), queen (4), and king (5).
     """
     embedding = np.zeros((len(boards), *EMBEDDING_SHAPE), dtype=int)
@@ -167,7 +167,8 @@ class NNetWrapper(NeuralNet):
             pi_losses, v_losses = AverageMeter(), AverageMeter()
 
             t = tqdm(
-                range(math.ceil(len(examples) / batch_size)), desc=f"Epoch {epoch}"
+                range(math.ceil(len(examples) / batch_size)),
+                desc=f"Epoch {epoch}/{epochs}",
             )
             for i in t:
                 boards, true_pis, true_vs = list(


### PR DESCRIPTION
Building on https://github.com/jamesbraza/cs234-dreamchess/pull/7:
- Adds `Elo` type alias
- Fixes typos in docstring for `embed` and `tdqm` progress bar
- Adds `TestNNet.play_against_stockfish`, `TestNNet.play_game_update_elo` to assess networks
