### PR TITLE
ResidualBlock, Training Improvements

### DIFF
--- a/azg_chess/__init__.py
+++ b/azg_chess/__init__.py
@@ -9,3 +9,9 @@ Useful Links:
 [2]: https://www.deepmind.com/publications/a-general-reinforcement-
      learning-algorithm-that-masters-chess-shogi-and-go-through-self-play
 """
+
+import os
+import sys
+
+# Enable azg submodule to be seen
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, "azg"))

--- a/azg_chess/nn.py
+++ b/azg_chess/nn.py
@@ -227,14 +227,10 @@ class NNetWrapper(NeuralNet):
                 *list(zip(*examples[(num_batches - 1) * batch_size :]))
             )
             writer.add_scalars(
-                "loss",
-                {
-                    "train_pi": train_losses_pi.avg,
-                    "train_V": train_losses_v.avg,
-                    "val_pi": loss_pi,
-                    "val_V": loss_v,
-                },
-                epoch,
+                "loss/pi", {"train": train_losses_pi.avg, "val": loss_pi}, epoch
+            )
+            writer.add_scalars(
+                "loss/V", {"train": train_losses_v.avg, "val": loss_v}, epoch
             )
 
     def predict(self, board: Board) -> tuple[Policy, float]:

--- a/azg_chess/nn.py
+++ b/azg_chess/nn.py
@@ -70,7 +70,7 @@ def conv_conversion(
 class ResidualBlock(nn.Module):
     """Basic residual block based on two Conv3d with BatchNorms."""
 
-    def __init__(self, in_channels: int = 256, out_channels: int = 256, **conv_kwargs):
+    def __init__(self, in_channels: int, out_channels: int, **conv_kwargs):
         super().__init__()
         conv_kwargs = {"kernel_size": 3, "padding": 1} | conv_kwargs
         self.non_residual = nn.Sequential(

--- a/azg_chess/nn.py
+++ b/azg_chess/nn.py
@@ -34,17 +34,17 @@ def embed(*boards: Board) -> npt.NDArray[int]:
         boards: Variable amount of Boards to embed.
 
     Returns:
-        Embedded representation of the board of shape (B, 8, 8, 6), where B is
+        Embedded representation of the board of shape (B, 6, 8, 8), where B is
             the batch size (number passed in), white is 1, black is -1, no
             piece is 0, and players are pawn (0), knight (1), bishop (2),
             rook (3), queen (4), and king (5).
     """
-    embedding = np.zeros((len(boards), *EMBEDDING_SHAPE), dtype=int)
+    batch_embedding = np.zeros((len(boards), *EMBEDDING_SHAPE), dtype=int)
     for i, board in enumerate(boards):
         for sq, pc in board.piece_map().items():
             bxyz = i, pc.piece_type - 1, chess.square_rank(sq), chess.square_file(sq)
-            embedding[bxyz] = 1 if pc.color else -1
-    return embedding
+            batch_embedding[bxyz] = 1 if pc.color else -1
+    return batch_embedding
 
 
 def conv_conversion(

--- a/azg_chess/players.py
+++ b/azg_chess/players.py
@@ -140,6 +140,7 @@ class AlphaZeroChessPlayer(ChessPlayer):
     ):
         super().__init__(player_id)
         self._nnet = NNetWrapper(game, **nnet_wrapper_kwargs)
+        self._nnet.nnet.eval()  # Place into eval mode
         if parameters_path is not None:
             self._nnet.load_checkpoint(*parameters_path)
         self._mcts = MCTS(game, self._nnet, mcts_args)

--- a/azg_chess/players.py
+++ b/azg_chess/players.py
@@ -7,12 +7,13 @@ import chess
 import chess.engine
 import numpy as np
 from azg.MCTS import MCTS
-from azg.utils import dotdict
 
 from azg_chess.game import WHITE_PLAYER, Board, action_to_move, move_to_action
 from azg_chess.nn import NNetWrapper
 
 if TYPE_CHECKING:
+    from azg.utils import dotdict
+
     from azg_chess.game import ActionIndex, ChessGame, PlayerID
 
 


### PR DESCRIPTION
- Adds `ResidualBlock` instead of straight `Conv3d` blocks
- Adds path so `azg` submodule can be seen
- Fixes docstring of `embed` and adds `embed` as a classmethod of `NNet` since they're closely coupled
- Fixes FC layers to not have missing `ReLU` and not go smaller than |A|
- Makes pi and V losses separate in `SummaryWriter`
- Adds eval flag for `AlphaZeroChessPlayer`