### PR TITLE
discern_elo algorithm

### DIFF
--- a/azg_chess/nn.py
+++ b/azg_chess/nn.py
@@ -182,7 +182,7 @@ class NNetWrapper(NeuralNet):
     def train(  # pylint: disable=too-many-locals
         self,
         examples: Sequence[tuple[Board, Policy, float]],
-        epochs: int = 10,
+        epochs: int = 20,
         batch_size: int = 64,
         l2_coefficient: float = 1e-4,
     ) -> None:

--- a/azg_chess/nn.py
+++ b/azg_chess/nn.py
@@ -68,7 +68,7 @@ def conv_conversion(
 
 
 class ResidualBlock(nn.Module):
-    """Basic residual block based on two Conv3d with BatchNorms."""
+    """Basic residual block based on two Conv3d with BatchNorm3ds."""
 
     def __init__(self, in_channels: int, out_channels: int, **conv_kwargs):
         super().__init__()

--- a/azg_chess/players.py
+++ b/azg_chess/players.py
@@ -117,6 +117,11 @@ class StockfishChessPlayer(ChessPlayer):
         option = self._engine.options["UCI_Elo"]
         return option.min, option.max
 
+    def clip_elo(self, elo: Elo) -> Elo:
+        """Clip an Elo to be in the range supported by Stockfish."""
+        min_elo, max_elo = self.elo_range
+        return min(max(elo, min_elo), max_elo)
+
     def choose_move(self, board: Board) -> chess.Move:
         # SEE: https://python-chess.readthedocs.io/en/latest/engine.html#playing
         result = self._engine.play(board, limit=chess.engine.Limit(time=0.1))

--- a/azg_chess/players.py
+++ b/azg_chess/players.py
@@ -5,11 +5,11 @@ from typing import TYPE_CHECKING, NamedTuple, Protocol, TypeVar
 
 import chess
 import chess.engine
-import geochri.src as geochri
 import numpy as np
 import torch
 from azg.MCTS import MCTS
 
+import geochri.src as geochri
 from azg_chess.game import WHITE_PLAYER, Board, action_to_move, move_to_action
 from azg_chess.nn import NNetWrapper
 
@@ -105,6 +105,12 @@ class StockfishChessPlayer(ChessPlayer):
         # NOTE: requires Stockfish 11 per here:
         # https://github.com/official-stockfish/Stockfish/issues/3358
         self._engine.configure({"UCI_LimitStrength": True, "UCI_Elo": engine_elo})
+
+    @property
+    def elo_range(self) -> tuple[int, int]:
+        """Get the range of Elo supported by Stockfish."""
+        option = self._engine.options["UCI_Elo"]
+        return option.min, option.max
 
     def choose_move(self, board: Board) -> chess.Move:
         # SEE: https://python-chess.readthedocs.io/en/latest/engine.html#playing

--- a/azg_chess/players.py
+++ b/azg_chess/players.py
@@ -82,8 +82,7 @@ class HumanChessPlayer(ChessPlayer):
                 print(f"Invalid UCI {uci_input}.")
 
 
-# NOTE: 0 is below the lowest possible Elo of 100
-NULL_ELO: Elo = 0
+NULL_ELO: Elo = 0  # NOTE: 0 is below the lowest possible Elo of 100
 
 
 class StockfishChessPlayer(ChessPlayer):

--- a/azg_chess/players.py
+++ b/azg_chess/players.py
@@ -16,6 +16,7 @@ from azg_chess.nn import NNetWrapper
 if TYPE_CHECKING:
     from azg.utils import dotdict
 
+    from azg_chess.chess_utils import Elo
     from azg_chess.game import ActionIndex, ChessGame, PlayerID
 
 
@@ -81,6 +82,10 @@ class HumanChessPlayer(ChessPlayer):
                 print(f"Invalid UCI {uci_input}.")
 
 
+# NOTE: 0 is below the lowest possible Elo of 100
+NULL_ELO: Elo = 0
+
+
 class StockfishChessPlayer(ChessPlayer):
     """
     Player whose decisions are made by the Stockfish chess engine.
@@ -98,7 +103,7 @@ class StockfishChessPlayer(ChessPlayer):
         self,
         player_id: PlayerID = WHITE_PLAYER,
         engine_path: str = DEFAULT_ENGINE_PATH,
-        engine_elo: int = DEFAULT_ELO,
+        engine_elo: Elo = DEFAULT_ELO,
     ):
         super().__init__(player_id)
         self._engine = chess.engine.SimpleEngine.popen_uci(engine_path)
@@ -107,7 +112,7 @@ class StockfishChessPlayer(ChessPlayer):
         self._engine.configure({"UCI_LimitStrength": True, "UCI_Elo": engine_elo})
 
     @property
-    def elo_range(self) -> tuple[int, int]:
+    def elo_range(self) -> tuple[Elo, Elo]:
         """Get the range of Elo supported by Stockfish."""
         option = self._engine.options["UCI_Elo"]
         return option.min, option.max

--- a/azg_chess/test.py
+++ b/azg_chess/test.py
@@ -1,3 +1,4 @@
+import collections
 import math
 from functools import partial
 from operator import gt, lt
@@ -23,6 +24,7 @@ from azg_chess.game import (
 )
 from azg_chess.nn import NNetWrapper
 from azg_chess.players import (
+    NULL_ELO,
     AlphaZeroChessPlayer,
     ChessPlayer,
     MCTSArgs,
@@ -30,7 +32,7 @@ from azg_chess.players import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
 
 @pytest.fixture(name="chess_game")
@@ -212,6 +214,7 @@ class TestNNet:
         coach = Coach(chess_game, nnet_wrapper, coach_args)
         coach.learn()
 
+    @pytest.mark.parametrize("mcts_args", [MCTSArgs()])
     def test_full_game(self, chess_game: ChessGame, mcts_args: MCTSArgs) -> None:
         az_player = AlphaZeroChessPlayer(
             chess_game, player_id=WHITE_PLAYER, mcts_args=mcts_args
@@ -249,8 +252,8 @@ class TestNNet:
     @staticmethod
     def play_game_update_elo(
         chess_game: ChessGame,
-        p1_p1elo: tuple[ChessPlayer, Elo],
-        p2_p2elo: tuple[ChessPlayer, Elo],
+        p1_p1elo: "Sequence[ChessPlayer, Elo]",
+        p2_p2elo: "Sequence[ChessPlayer, Elo]",
         k_factor: int = ICC_K_FACTOR,
         verbose: bool = False,
     ) -> tuple[Elo, Elo]:
@@ -263,6 +266,74 @@ class TestNNet:
         )
         winner_id: Literal[-1, 0, 1] = arena.playGame(verbose)
         return update_elo(p1_elo, p2_elo, winner_id, k_factor)
+
+    @classmethod
+    def discern_elo(
+        cls,
+        chess_game: ChessGame,
+        unknown_elo_player: ChessPlayer,
+        unknown_elo_assumption: int = 1350,
+        stockfish_initial_elo: Elo = 1350,
+        window_width: int = 10,
+        desired_stability: Elo = 100,
+        n_exit: int = 10,
+        verbose: bool = False,
+    ) -> Elo:
+        """
+        Discern the Elo of an unknown player.
+
+        Args:
+            chess_game: Chess game to use in the arena.
+            unknown_elo_player: Player of unknown Elo.
+            unknown_elo_assumption: Assumption of unknown player's Elo.
+            stockfish_initial_elo: Initial Elo assumption for Stockfish player.
+            window_width: Number of games in the stability sliding window.
+            desired_stability: Range of values in the sliding window to
+                consider Elo as having stabilized.
+            n_exit: Failover max number of games if Elo doesn't stabilize.  If
+                the failover threshold is hit, use the last updated Elo.
+            verbose: Set True to print out game updates.
+
+        Returns:
+            Stabilized or last seen Elo of the known player.
+        """
+        assert unknown_elo_player.id == WHITE_PLAYER
+        make_stockfish = partial(StockfishChessPlayer, player_id=BLACK_PLAYER)
+        known = [
+            make_stockfish(engine_elo=stockfish_initial_elo),
+            stockfish_initial_elo,
+        ]
+
+        def update_known(elo: Elo) -> None:
+            elo = known[0].clip_elo(elo)
+            if known[1] != elo:
+                known[0] = make_stockfish(engine_elo=elo)
+                known[1] = elo
+
+        unknown_elos_window = collections.deque(
+            [NULL_ELO] * (window_width - 1) + [unknown_elo_assumption],
+            maxlen=window_width,
+        )
+        for _ in range(n_exit):
+            if (
+                max(unknown_elos_window) - min(unknown_elos_window) <= desired_stability
+                or all(
+                    NULL_ELO < elo < known[0].elo_range[0]
+                    for elo in unknown_elos_window
+                )
+                or all(elo > known[0].elo_range[1] for elo in unknown_elos_window)
+            ):
+                break
+            updated_unknown_elo, _ = cls.play_game_update_elo(
+                chess_game,
+                p1_p1elo=(unknown_elo_player, unknown_elos_window[-1]),
+                p2_p2elo=known,
+                verbose=verbose,
+            )
+            unknown_elos_window.append(updated_unknown_elo)
+            # Match Stockfish to the Elo of the unknown player each game
+            update_known(elo=updated_unknown_elo)
+        return unknown_elos_window[-1]
 
 
 class TestChessUtils:

--- a/azg_chess/test.py
+++ b/azg_chess/test.py
@@ -272,7 +272,7 @@ class TestNNet:
         cls,
         chess_game: ChessGame,
         unknown_elo_player: ChessPlayer,
-        unknown_elo_assumption: int = 1350,
+        unknown_elo_assumption: Elo = 1350,
         stockfish_initial_elo: Elo = 1350,
         window_width: int = 10,
         desired_stability: Elo = 100,


### PR DESCRIPTION
- Added support for Elo range to `StockfishChessPlayer` and null Elo
 - Increased default number of `NNet` training epochs to 20
 - Added ability to restore from checkpoint into `test_coach`
 - Moved `play_game_update_elo` to allow any `Sequence`
 - Added `discern_elo` algorithm to discern the Elo of an unknown-Elo player