### PR TITLE
Docs and CoachArgs.load_model

### DIFF
--- a/azg_chess/players.py
+++ b/azg_chess/players.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, NamedTuple, Protocol, TypeVar
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, TypeVar
 
 import chess
 import chess.engine
@@ -134,7 +135,8 @@ class StockfishChessPlayer(ChessPlayer):
         self._engine.close()
 
 
-class MCTSArgs(NamedTuple):
+@dataclass
+class MCTSArgs:
     """
     Data structure to configure Monte-Carlo Tree Search object.
 

--- a/azg_chess/test.py
+++ b/azg_chess/test.py
@@ -1,5 +1,6 @@
 import collections
 import math
+from dataclasses import dataclass
 from functools import partial
 from operator import gt, lt
 from typing import TYPE_CHECKING, Literal
@@ -182,6 +183,7 @@ def outcomes_to_win_percentage(
     return n_wins / n_total
 
 
+@dataclass
 class CoachArgs(MCTSArgs):
     """Data structure to configure the Coach class."""
 
@@ -202,8 +204,9 @@ class CoachArgs(MCTSArgs):
     # Set True to load in the model weights from checkpoint and training
     # examples from the load_folder_file
     load_model: bool = False
-    # Two-tuple of folder and filename where training examples are housed
-    load_folder_file: tuple[str, str] = "checkpoints", "checkpoint_0.pth.tar"
+    # Two-tuple of folder and filename where training examples are housed, for
+    # use inside Coach.loadTrainExamples
+    load_folder_file: tuple[str, str] = "checkpoints", "checkpoint.pth.tar"
     # Max amount of training examples to keep in the history, dropping the
     # oldest example beyond that before adding a new one (like a FIFO queue)
     numItersForTrainExamplesHistory: int = 20
@@ -211,27 +214,31 @@ class CoachArgs(MCTSArgs):
 
 class TestNNet:
     @pytest.mark.parametrize(
-        ("coach_args", "parameters_path", "preload_examples"),
+        ("coach_args", "preload_examples"),
         [
-            pytest.param(CoachArgs(), None, False, id="from_scratch"),
+            pytest.param(CoachArgs(), False, id="from_scratch"),
             pytest.param(
-                CoachArgs(), ("checkpoints", "temp.pth.tar"), True, id="resume"
+                CoachArgs(
+                    load_model=True, load_folder_file=("checkpoints", "temp.pth.tar")
+                ),
+                True,
+                id="resume",
             ),
             pytest.param(
-                CoachArgs(), ("checkpoints", "best.pth.tar"), False, id="iterate"
+                CoachArgs(
+                    load_model=True, load_folder_file=("checkpoints", "best.pth.tar")
+                ),
+                False,
+                id="iterate",
             ),
         ],
     )
     def test_coach(
-        self,
-        chess_game: ChessGame,
-        coach_args: CoachArgs,
-        parameters_path: tuple[str, str] | None,
-        preload_examples: bool,
+        self, chess_game: ChessGame, coach_args: CoachArgs, preload_examples: bool
     ) -> None:
         nnet_wrapper = NNetWrapper(chess_game)
-        if parameters_path is not None:
-            nnet_wrapper.load_checkpoint(*parameters_path)
+        if coach_args.load_model:
+            nnet_wrapper.load_checkpoint(*coach_args.load_folder_file)
         coach = Coach(chess_game, nnet_wrapper, coach_args)
         if preload_examples:
             coach.loadTrainExamples()

--- a/azg_chess/test.py
+++ b/azg_chess/test.py
@@ -184,7 +184,7 @@ def outcomes_to_win_percentage(
 
 
 @dataclass
-class CoachArgs(MCTSArgs):
+class CoachArgs(MCTSArgs):  # pylint: disable=too-many-instance-attributes
     """Data structure to configure the Coach class."""
 
     # Number of training iterations


### PR DESCRIPTION
- Documented `NNetWrapper` signature decision making and forced `game` to be the only positional arg
- Made `MCTSArgs`/`CoachArgs` into `dataclass`es so they can have individual params changed
- Removed `parameters_path` in favor of `CoachArgs.load_model` like many do in `azg`