### PR TITLE
Optimization: np.array before torch.tensor

### DIFF
--- a/azg_chess/nn.py
+++ b/azg_chess/nn.py
@@ -235,8 +235,11 @@ class NNetWrapper(NeuralNet):
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Calculate pi, V, and total loss given example data."""
         pred_pis, pred_vs = self.nnet(self.nnet.embed(*boards, device=self._device))
+        # Why cast to np.array? SEE: https://github.com/pytorch/pytorch/issues/13918
         true_pis, true_vs = (
-            torch.tensor(x, device=self._device, dtype=torch.float32)
+            torch.tensor(
+                np.array(x, dtype=float), device=self._device, dtype=torch.float32
+            )
             for x in [true_pis, true_vs]
         )
         loss_pi = nn.functional.cross_entropy(input=pred_pis, target=true_pis)

--- a/azg_chess/test.py
+++ b/azg_chess/test.py
@@ -214,31 +214,30 @@ class CoachArgs(MCTSArgs):  # pylint: disable=too-many-instance-attributes
 
 class TestNNet:
     @pytest.mark.parametrize(
-        ("coach_args", "preload_examples"),
+        ("coach_args", "parameters_path", "preload_examples"),
         [
-            pytest.param(CoachArgs(), False, id="from_scratch"),
+            pytest.param(CoachArgs(), None, False, id="from_scratch"),
             pytest.param(
-                CoachArgs(
-                    load_model=True, load_folder_file=("checkpoints", "temp.pth.tar")
-                ),
+                CoachArgs(load_model=True),
+                ("checkpoints", "temp.pth.tar"),
                 True,
                 id="resume",
             ),
             pytest.param(
-                CoachArgs(
-                    load_model=True, load_folder_file=("checkpoints", "best.pth.tar")
-                ),
-                False,
-                id="iterate",
+                CoachArgs(), ("checkpoints", "best.pth.tar"), False, id="iterate"
             ),
         ],
     )
     def test_coach(
-        self, chess_game: ChessGame, coach_args: CoachArgs, preload_examples: bool
+        self,
+        chess_game: ChessGame,
+        coach_args: CoachArgs,
+        parameters_path: tuple[str, str] | None,
+        preload_examples: bool,
     ) -> None:
         nnet_wrapper = NNetWrapper(chess_game)
-        if coach_args.load_model:
-            nnet_wrapper.load_checkpoint(*coach_args.load_folder_file)
+        if coach_args.load_model and parameters_path is not None:
+            nnet_wrapper.load_checkpoint(*parameters_path)
         coach = Coach(chess_game, nnet_wrapper, coach_args)
         if preload_examples:
             coach.loadTrainExamples()


### PR DESCRIPTION
- Added a training-time optimization (pre-casting to `np.array` inside loss calculation)
- Brought back `parameters_path` to `TestNNet.test_coach` since it was useful