### PR TITLE
AlphaZero Player bugfixes, torch.as_tensor optimization

### DIFF
--- a/azg_chess/nn.py
+++ b/azg_chess/nn.py
@@ -168,7 +168,7 @@ class NNet(nn.Module):
 
     def embed(self, *boards: Board, device: torch.device | None = None) -> torch.Tensor:
         """Embed the input boards into a Tensor for the forward pass."""
-        return torch.tensor(
+        return torch.as_tensor(
             self._embed_func(*boards), dtype=torch.float32, device=device
         )
 
@@ -237,9 +237,7 @@ class NNetWrapper(NeuralNet):
         pred_pis, pred_vs = self.nnet(self.nnet.embed(*boards, device=self._device))
         # Why cast to np.array? SEE: https://github.com/pytorch/pytorch/issues/13918
         true_pis, true_vs = (
-            torch.tensor(
-                np.array(x, dtype=float), device=self._device, dtype=torch.float32
-            )
+            torch.as_tensor(np.array(x, dtype=np.float32), device=self._device)
             for x in [true_pis, true_vs]
         )
         loss_pi = nn.functional.cross_entropy(input=pred_pis, target=true_pis)

--- a/azg_chess/players.py
+++ b/azg_chess/players.py
@@ -159,10 +159,11 @@ class AlphaZeroChessPlayer(ChessPlayer):
         player_id: PlayerID = WHITE_PLAYER,
         mcts_args: MCTSArgs | dotdict = DEFAULT_MCTS_ARGS,
         parameters_path: tuple[str, str] | None = None,
+        nnet_type: type[NNetWrapper] = NNetWrapper,
         **nnet_wrapper_kwargs,
     ):
         super().__init__(player_id)
-        self._nnet = NNetWrapper(game, **nnet_wrapper_kwargs)
+        self._nnet = nnet_type(game, **nnet_wrapper_kwargs)
         self._nnet.nnet.eval()  # Place into eval mode
         if parameters_path is not None:
             self._nnet.load_checkpoint(*parameters_path)


### PR DESCRIPTION
- I learned of `torch.as_tensor`, which prevents making a copy of numpy arrays as long as `dtype`s match
- Enabled `AlphaZeroChessPlayer` to handle `nnet_types` for using `UnsignedNNetWrapper`
- Updated geochri fork for bugfix in `UCT_search`