### PR TITLE
GeochriPlayer bugfixes

### DIFF
--- a/azg_chess/players.py
+++ b/azg_chess/players.py
@@ -213,13 +213,11 @@ class GeochriPlayer(ChessPlayer):
             if prom[0] in chess.PIECE_SYMBOLS:
                 index = chess.PIECE_SYMBOLS.index(prom[0])
                 return chess.Piece(chess.PIECE_TYPES[index], chess.BLACK)
-            elif prom[0].lower() in chess.PIECE_SYMBOLS:
+            if prom[0].lower() in chess.PIECE_SYMBOLS:
                 index = chess.PIECE_SYMBOLS.index(prom[0].lower())
                 return chess.Piece(chess.PIECE_TYPES[index], chess.WHITE)
-            else:
-                raise NotImplementedError(f"Unexpected promotion piece {prom[0]}.")
-        else:
-            return None
+            raise NotImplementedError(f"Unexpected promotion piece {prom[0]}.")
+        return None
 
     def choose_move(self, board: Board) -> chess.Move:
         geochri_board = geochri.src.chess_utils.load_chessboard_to_Geochri(board)

--- a/azg_chess/players.py
+++ b/azg_chess/players.py
@@ -204,6 +204,23 @@ class GeochriPlayer(ChessPlayer):
             )
             self._net.load_state_dict(checkpoint["state_dict"])
 
+    @staticmethod
+    def _parse_promotion(prom: list[str | None]) -> chess.Piece | None:
+        """Parse a geochri promotion to a chess.Piece or None (no promotion)."""
+        if len(prom) > 1:
+            raise NotImplementedError(f"Unhandled promotion {prom} of 2+ pieces.")
+        if len(prom) == 1 and prom[0] is not None:
+            if prom[0] in chess.PIECE_SYMBOLS:
+                index = chess.PIECE_SYMBOLS.index(prom[0])
+                return chess.Piece(chess.PIECE_TYPES[index], chess.BLACK)
+            elif prom[0].lower() in chess.PIECE_SYMBOLS:
+                index = chess.PIECE_SYMBOLS.index(prom[0].lower())
+                return chess.Piece(chess.PIECE_TYPES[index], chess.WHITE)
+            else:
+                raise NotImplementedError(f"Unexpected promotion piece {prom[0]}.")
+        else:
+            return None
+
     def choose_move(self, board: Board) -> chess.Move:
         geochri_board = geochri.src.chess_utils.load_chessboard_to_Geochri(board)
 
@@ -214,22 +231,10 @@ class GeochriPlayer(ChessPlayer):
             geochri_board, encoded=best_move
         )
 
-        if len(prom) > 1:
-            raise NotImplementedError(f"Unhandled promotion {prom} of 2+ pieces.")
-        if len(prom) == 1 and prom[0] is not None:
-            if prom[0] in chess.PIECE_SYMBOLS:
-                index = chess.PIECE_SYMBOLS.index(prom[0])
-                promotion_piece = chess.Piece(chess.PIECE_TYPES[index], chess.BLACK)
-            elif prom[0].lower() in chess.PIECE_SYMBOLS:
-                index = chess.PIECE_SYMBOLS.index(prom[0].lower())
-                promotion_piece = chess.Piece(chess.PIECE_TYPES[index], chess.WHITE)
-            else:
-                raise NotImplementedError(f"Unexpected promotion piece {prom[0]}.")
-        else:
-            promotion_piece = None
-
         from_square, to_square = (
             chess.parse_square(chr(pos[0][1] + ord("a")) + str(8 - pos[0][0]))
             for pos in (i_pos, f_pos)
         )
-        return chess.Move(from_square, to_square, promotion_piece)
+        move = chess.Move(from_square, to_square, self._parse_promotion(prom))
+        assert move in board.legal_moves, f"Chose invalid move {move} in board {board}."
+        return move

--- a/azg_chess/players.py
+++ b/azg_chess/players.py
@@ -205,19 +205,17 @@ class GeochriPlayer(ChessPlayer):
             self._net.load_state_dict(checkpoint["state_dict"])
 
     @staticmethod
-    def _parse_promotion(prom: list[str | None]) -> chess.Piece | None:
-        """Parse a geochri promotion to a chess.Piece or None (no promotion)."""
+    def _parse_promotion(prom: list[str | None]) -> chess.PieceType | None:
+        """Convert a geochri promotion into a promotion piece type, or None."""
         if len(prom) > 1:
             raise NotImplementedError(f"Unhandled promotion {prom} of 2+ pieces.")
         if len(prom) == 1 and prom[0] is not None:
             if prom[0] in chess.PIECE_SYMBOLS:
-                index = chess.PIECE_SYMBOLS.index(prom[0])
-                return chess.Piece(chess.PIECE_TYPES[index], chess.BLACK)
+                return chess.PIECE_SYMBOLS.index(prom[0])
             if prom[0].lower() in chess.PIECE_SYMBOLS:
-                index = chess.PIECE_SYMBOLS.index(prom[0].lower())
-                return chess.Piece(chess.PIECE_TYPES[index], chess.WHITE)
+                return chess.PIECE_SYMBOLS.index(prom[0].lower())
             raise NotImplementedError(f"Unexpected promotion piece {prom[0]}.")
-        return None
+        return None  # No promotion
 
     def choose_move(self, board: Board) -> chess.Move:
         geochri_board = geochri.src.chess_utils.load_chessboard_to_Geochri(board)

--- a/azg_chess/test.py
+++ b/azg_chess/test.py
@@ -1,5 +1,6 @@
 import collections
 import math
+import os
 from dataclasses import dataclass
 from functools import partial
 from operator import gt, lt
@@ -28,6 +29,7 @@ from azg_chess.players import (
     NULL_ELO,
     AlphaZeroChessPlayer,
     ChessPlayer,
+    GeochriPlayer,
     MCTSArgs,
     RandomChessPlayer,
     StockfishChessPlayer,
@@ -265,13 +267,39 @@ class TestNNet:
             chess_game, WHITE_PLAYER, mcts_args, parameters_path
         )
 
-        outcomes_1350_elo = self.play_many_games(
+        # 1. Play AlphaZeroChessPlayer against 1350 Elo and random players
+        outcomes_az_1350_elo = self.play_many_games(
             chess_game, az_player, StockfishChessPlayer(BLACK_PLAYER, engine_elo=1350)
         )
-        outcomes_random = self.play_many_games(
+        print(f"AlphaZeroChessPlayer against 1350 Elo: {outcomes_az_1350_elo}.")
+        outcomes_az_random = self.play_many_games(
             chess_game, az_player, RandomChessPlayer(BLACK_PLAYER)
         )
-        _ = outcomes_1350_elo, outcomes_random
+        print(f"AlphaZeroChessPlayer against random: {outcomes_az_random}.")
+
+        geochri_player = GeochriPlayer(
+            BLACK_PLAYER,
+            parameters_file=os.path.expanduser("~/Downloads/geochri_weights.tar"),
+        )
+
+        # 2. Play GeochriPlayer against 1350 Elo and random players
+        outcomes_geochri_1350_elo = self.play_many_games(
+            chess_game,
+            geochri_player,
+            StockfishChessPlayer(WHITE_PLAYER, engine_elo=1350),
+        )
+        print(f"GeochriPlayer against 1350 Elo: {outcomes_geochri_1350_elo}.")
+        outcomes_geochri_random = self.play_many_games(
+            chess_game, geochri_player, RandomChessPlayer(WHITE_PLAYER)
+        )
+        print(f"GeochriPlayer against random: {outcomes_geochri_random}.")
+
+        # 3. Play AlphaZeroChessPlayer against GeochriPlayer
+        outcomes_az_geochri = self.play_many_games(
+            chess_game, az_player, geochri_player
+        )
+        print(f"AlphaZeroChessPlayer against GeochriPlayer: {outcomes_az_geochri}.")
+        _ = 0  # Debug here
 
     @staticmethod
     def play_many_games(


### PR DESCRIPTION
More `GeochriPlayer` fixes after https://github.com/jamesbraza/cs234-dreamchess/pull/14:
- Fixes `GeochriPlayer`'s pawn promotion logic to handle `[None]` and return piece types (not pieces)
- Adds matches against `GeochriPlayer` to `test_full_game`
- Updates geochri fork for fixes to `board.move_rules_p`