### PR TITLE
AlphaGo Zero Network Architecture

### DIFF
--- a/azg_chess/nn.py
+++ b/azg_chess/nn.py
@@ -29,8 +29,10 @@ def discern_gpu_mac_cpu_device() -> torch.device:
     if torch.cuda.is_available():
         return torch.device("cuda")
     if torch.backends.mps.is_available():
-        # As of 3/18/2023, nn.Conv3d was not supported on the mps backend per
-        # https://github.com/pytorch/pytorch/issues/77764
+        # As of 3/18/2023, aten::nonzero was not supported on macOS 12.6 with
+        # torch 2.0.0, and torch 1.3.1 didn't support aten::nonzero at all
+        # SEE: https://github.com/pytorch/pytorch/issues/77764
+        # SEE: https://github.com/pytorch/pytorch/commit/38de981e160732bce5d90bace0b40d63dba31bf1
         pass
     return torch.device("cpu")  # Fallback
 

--- a/azg_chess/nn.py
+++ b/azg_chess/nn.py
@@ -154,7 +154,7 @@ class NNet(nn.Module):
         # NOTE: confirm this matches, as otherwise the fully-connected layers'
         # input shape would not be larger than the action size
         self._embed_func, shape = embed_func_shape
-        assert policy_channels * math.prod(shape), game.getActionSize()
+        assert policy_channels * math.prod(shape) >= game.getActionSize()
         # NOTE: leave pi as raw scores (don't apply Softmax) to directly use
         # nn.functional.cross_entropy
         self.policy_head = nn.Sequential(

--- a/azg_chess/nn.py
+++ b/azg_chess/nn.py
@@ -121,7 +121,7 @@ class NNet(nn.Module):
         game: ChessGame,
         residual_channels: int = 256,
         num_residual_layers: int = 19,
-        policy_channels: int = 6,
+        policy_channels: int = 128,
         value_hidden_units: int = 256,
         dropout_p: float = 0.8,
         embed_func_shape: tuple[
@@ -132,7 +132,7 @@ class NNet(nn.Module):
         Initialize.
 
         Args:
-            game: Game, to extract action sizes and confirm board size.
+            game: Game, to extract action sizes.
             residual_channels: Number of channels in the residual layers,
                 referred to as C sometimes below.
             num_residual_layers: Number of residual layers.


### PR DESCRIPTION
Matches the network architecture from [Mastering the game of Go without human knowledge](https://www.nature.com/articles/nature24270)
- Switches from `Conv3d` to `Conv2d`
- Adds many more `ResidualBlock` and removes `fc_layers` network